### PR TITLE
Make compatible with latest EC2 updates

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,6 +1,0 @@
-var default_data = {
-                        always_override_user: false,
-                        rdp_style: "MS",
-                        rdp_user: "Administrator",
-                        ssh_user: "ec2-user"
-                    }

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.console.aws.amazon.com/ec2/v2/*",
-        "https://console.aws.amazon.com/ecs/v2/*"
+        "https://*.console.aws.amazon.com/ec2/v2/*"
       ],
       "js": [
         "page.js",
@@ -29,15 +28,12 @@
       "38": "icons/icon38.png"
     },
     "default_popup": "options.html",
-    "default_title": "AWS Links"
+    "default_title": "AWS SSH RDP Links"
   },
   "icons": { "16": "icons/icon16.png",
            "48": "icons/icon48.png",
           "128": "icons/icon128.png" },
   "permissions": [
-    "activeTab",
-    "storage",
-    "https://*.console.aws.amazon.com/ec2/v2/*",
-    "https://console.aws.amazon.com/ec2/v2/*"
+    "storage"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
         "https://console.aws.amazon.com/ecs/v2/*"
       ],
       "js": [
-        "defaults.js",
         "page.js",
         "jquery-2.2.2.min.js"
       ],

--- a/options.html
+++ b/options.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <script src="jquery-2.2.2.min.js"></script>
-  <script src="defaults.js"></script>
   <script src="options.js"></script>
 
   <title>AWS SSH RDP Options</title>
@@ -42,7 +41,7 @@
   </div>
 
   <div>
-    <a href="https://github.com/natefox/aws-ssh-rdp-links">Website</a> | 
+    <a href="https://github.com/natefox/aws-ssh-rdp-links">Website</a> |
     <a href="https://github.com/natefox/aws-ssh-rdp-links/issues">Report a bug?</a> | Ver: <span id="version"></span>
   </div>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,3 +1,10 @@
+var default_data = {
+  always_override_user: false,
+  rdp_style: "MS",
+  rdp_user: "Administrator",
+  ssh_user: "ec2-user"
+}
+
 // Saves options to chrome.storage.sync.
 function save_options() {
   var always_override_user = $("#always_override_user").is(":checked");
@@ -31,4 +38,3 @@ $( document ).ready(function() {
   load_options();
   $("#save").click(save_options);
 });
-

--- a/page.js
+++ b/page.js
@@ -18,22 +18,21 @@ function get_storage() {
     chrome.storage.sync.get(default_data, function(items){
         saved_data = items
         window.setTimeout(function(){
-            go();    
-        }, 400);    
+            go();
+        }, 400);
     })
 }
 
 function go() {
-    private_dns = get_selector(4,0);
-    private_ip = get_selector(5,0);
+    private_dns = get_selector(4,1);
+    private_ip = get_selector(5,1);
 
     public_dns = get_selector(1,1);
     public_ip = get_selector(2,1);
 
-    elastic_ip = get_selector(3,1);
+    elastic_ip = get_selector(4,0);
 
-    top_row = $("div.GMB span:eq(2)")
-
+    top_row = $("div.HOB span:eq(2)")
 
     add_to_field(private_ip)
     add_to_field(public_ip)
@@ -56,11 +55,11 @@ function add_to_field(fld, is_top_row = false) {
     span = ($("span.awssshrdplink", fld).length)
             ? $("span.awssshrdplink", fld).empty()
             : $("<span />", {class: "awssshrdplink"})
-    
+
     platform = get_selector(8,1).text();
 
     str_to_add = (platform == "windows")
-                ? create_rdp(field_text) 
+                ? create_rdp(field_text)
                 : create_ssh(field_text)
 
     span.append(str_to_add)
@@ -95,7 +94,7 @@ function get_ssh_user() {
     default_user = saved_data['ssh_user']
 
     ami = get_selector(7,1).text();
-    if (ami.indexOf("ubuntu") > -1) 
+    if (ami.indexOf("ubuntu") > -1)
         user = "ubuntu"
     else if (ami.indexOf("amzn") > -1)
         user = "ec2-user"
@@ -103,7 +102,7 @@ function get_ssh_user() {
         user = "ec2-user"
     else if (ami.indexOf("suse-sles") > -1)
         user = "ec2-user"
-    else 
+    else
         user = default_user
 
     if (saved_data['always_override_user'])
@@ -121,5 +120,5 @@ function get_windows_user() {
 }
 
 function get_selector(row,div) {
-    return $("table.AK > tbody tr:eq("+row+") div.CK:eq("+div+")")
+    return $(".gwt-TabLayoutPanelContent table > tbody tr:eq("+row+") div.LJ:eq("+div+")")
 }

--- a/page.js
+++ b/page.js
@@ -120,5 +120,5 @@ function get_windows_user() {
 }
 
 function get_selector(row,div) {
-    return $(".gwt-TabLayoutPanelContent table > tbody tr:eq("+row+") div.LJ:eq("+div+")")
+    return $(`.gwt-TabLayoutPanelContent table > tbody tr:eq(${row}) div > div > div:eq(${div*2+1})`)
 }

--- a/page.js
+++ b/page.js
@@ -107,7 +107,7 @@ function create_rdp(host) {
 function get_ssh_user() {
     default_user = saved_data['ssh_user']
 
-    ami = get_selector(7,1).text();
+    ami = get_selector(8,0).text();
     if (ami.indexOf("ubuntu") > -1)
         user = "ubuntu"
     else if (ami.indexOf("amzn") > -1)

--- a/page.js
+++ b/page.js
@@ -7,6 +7,7 @@ chrome.storage.onChanged.addListener(function(){
 // I really want something like this!
 // http://stackoverflow.com/a/3597640/517606
 document.addEventListener('DOMContentLoaded', function() {
+    setTimeout(get_storage, 4000);
     $(document).click(function(){
         if (window.location.hash.startsWith("#Instances"))
             get_storage();

--- a/page.js
+++ b/page.js
@@ -1,4 +1,10 @@
 var saved_data = {}
+var default_data = {
+  always_override_user: false,
+  rdp_style: "MS",
+  rdp_user: "Administrator",
+  ssh_user: "ec2-user"
+}
 
 chrome.storage.onChanged.addListener(function(){
     get_storage();

--- a/page.js
+++ b/page.js
@@ -50,6 +50,11 @@ function add_to_field(fld, is_top_row = false) {
         ? fld.contents().first().text().split(" ").reverse()[0]
         : fld.contents().first().text()
 
+    // remove * from EIP
+    if (field_text.endsWith("*")) {
+      field_text = field_text.substr(0, field_text.length-1);
+    }
+
     if (field_text.indexOf("-") == 0 || field_text.trim().length == 0)
         return
 

--- a/page.js
+++ b/page.js
@@ -31,13 +31,15 @@ function go() {
     public_dns = get_selector(1,1);
     public_ip = get_selector(2,1);
 
-    elastic_ip = get_selector(4,0);
+    elastic_ips = get_selector(4,0);
+    elastic_ips.find("li").each(function(i, eip) {
+      add_to_field($(eip))
+    });
 
     top_row = $("div.HOB span:eq(2)")
 
     add_to_field(private_ip)
     add_to_field(public_ip)
-    add_to_field(elastic_ip)
 
     add_to_field(private_dns)
     add_to_field(public_dns)

--- a/page.js
+++ b/page.js
@@ -70,7 +70,7 @@ function add_to_field(fld, is_top_row = false) {
             ? $("span.awssshrdplink", fld).empty()
             : $("<span />", {class: "awssshrdplink"})
 
-    platform = get_selector(8,1).text();
+    platform = get_selector(9,0).text();
 
     str_to_add = (platform == "windows")
                 ? create_rdp(field_text)


### PR DESCRIPTION
I think this extension broke when IPv6 was launched, but I wasn't using it at the time so I don't know for sure. I hope these changes will make it more resilient, but if they reorder things again, it will break again.

I saw some work [on another fork](https://github.com/natefox/aws-ssh-rdp-links/commit/ef97bdb5866aa9b8ca71744be687890bde4d9248) that is using the text to find the column. But it won't work with other languages. Maybe it can be incorporated in a future update.

Let me know if I changed too much in one go. I tried to explain my reasoning in the commit messages.

Btw, here's what multiple ENIs with their own EIP look like when they're assigned to a single instance:
<img width="291" alt="multiple eips" src="https://cloud.githubusercontent.com/assets/1991151/23054692/48c35ed6-f496-11e6-9ddc-f2fe1e294051.png">
