### PR TITLE
Fix bug where SSH links are added to the wrong console

### DIFF
--- a/options.html
+++ b/options.html
@@ -41,8 +41,8 @@
   </div>
 
   <div>
-    <a href="https://github.com/natefox/aws-ssh-rdp-links">Website</a> |
-    <a href="https://github.com/natefox/aws-ssh-rdp-links/issues">Report a bug?</a> | Ver: <span id="version"></span>
+    <a target="_blank" href="https://github.com/natefox/aws-ssh-rdp-links">Website</a> |
+    <a target="_blank" href="https://github.com/natefox/aws-ssh-rdp-links/issues">Report a bug?</a> | Ver: <span id="version"></span>
   </div>
 </body>
 </html>

--- a/page.js
+++ b/page.js
@@ -15,13 +15,13 @@ chrome.storage.onChanged.addListener(function(){
 document.addEventListener('DOMContentLoaded', function() {
     setTimeout(get_storage, 4000);
     $(document).click(function(){
-        if (window.location.hash.startsWith("#Instances"))
-            get_storage();
+        get_storage();
     })
 });
 
 
 function get_storage() {
+    if (!window.location.hash.startsWith("#Instances")) return;
     chrome.storage.sync.get(default_data, function(items){
         saved_data = items
         window.setTimeout(function(){


### PR DESCRIPTION
So it turns out I did not only fix bugs in my last PR, but I also added a brand new one. :)

Bug was introduced in this commit: https://github.com/natefox/aws-ssh-rdp-links/commit/73781d851169edc1c62e388b6b10e0328fa9a39d

If you follow a link to something else than `#Instances:`, for example, the security group list, the extension would add SSH links after 4 seconds. Example link: https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SecurityGroups:groupId=sg-0123456;sort=groupName (replace sg-0123456 with a valid security group id)

To fix it, I just moved the url check to `get_storage` instead.